### PR TITLE
Update sharedcount_updated post meta after retrieving count

### DIFF
--- a/sharedcount.php
+++ b/sharedcount.php
@@ -155,6 +155,8 @@ if ( !class_exists( 'SharedCount' ) ) {
 				if ( $count > $current ) {
 					update_post_meta( $post->ID, 'sharedcount_count', $count );
 				}
+
+				update_post_meta( $post->ID, 'sharedcount_updated', current_time( 'mysql', true ) );
 			}
 			else {
 				$count = $current;

--- a/sharedcount.php
+++ b/sharedcount.php
@@ -46,7 +46,7 @@ if ( !class_exists( 'SharedCount' ) ) {
 		 * Schedule job for fetching counts.
 		 */
 		static function sharedcount_activate() {
-			$recurrance = apply_filters( 'sharedcount_fetch_recurrance', 'twicedaily' );
+			$recurrance = apply_filters( 'sharedcount_fetch_recurrance', 'hourly' );
 
 			wp_schedule_event( time(), $recurrance, 'sharedcount_fetch_counts' );
 		}
@@ -72,8 +72,8 @@ if ( !class_exists( 'SharedCount' ) ) {
 					array(
 						'key' => 'sharedcount_updated',
 						'type' => 'DATETIME',
-						// Anything over an hour old
-						'value' => gmdate( 'Y-m-d H:i:s', time() - 3600 ),
+						// Anything over 12 hours old
+						'value' => gmdate( 'Y-m-d H:i:s', time() - 43200 ),
 						'compare' => '<'
 					),
 					array(

--- a/sharedcount.php
+++ b/sharedcount.php
@@ -34,21 +34,17 @@ if ( !class_exists( 'SharedCount' ) ) {
 		static function init() {
 			$c = get_called_class();
 
-			register_activation_hook( __FILE__, array( $c, 'sharedcount_activate' ) );
 			register_deactivation_hook( __FILE__, array( $c, 'sharedcount_deactivate' ) );
+
+			// Schedule job for fetching counts.
+			$recurrance = apply_filters( 'sharedcount_fetch_recurrance', 'hourly' );
+			if ( ! wp_next_scheduled( 'sharedcount_fetch_counts' ) ) {
+				wp_schedule_event( current_time( 'timestamp' ), $recurrance, 'sharedcount_fetch_counts' );
+			}
 
 			add_action( 'customize_register', array( $c, 'customize_register' ) );
 			add_action( 'sharedcount_render', array( $c, 'render_count' ) );
 			add_action( 'sharedcount_fetch_counts', array( $c, 'fetch_counts' ) );
-		}
-
-		/**
-		 * Schedule job for fetching counts.
-		 */
-		static function sharedcount_activate() {
-			$recurrance = apply_filters( 'sharedcount_fetch_recurrance', 'hourly' );
-
-			wp_schedule_event( time(), $recurrance, 'sharedcount_fetch_counts' );
 		}
 
 		/**

--- a/sharedcount.php
+++ b/sharedcount.php
@@ -224,8 +224,6 @@ if ( !class_exists( 'SharedCount' ) ) {
 				if ( $count > $current ) {
 					update_post_meta( $post->ID, 'sharedcount_count', $count );
 				}
-
-				update_post_meta( $post->ID, 'sharedcount_updated', current_time( 'mysql', true ) );
 			}
 			else {
 				$count = $current;


### PR DESCRIPTION
Update "sharedcount_updated" post meta after count is retrieved using the get_counts() function as done in the CLI command. This fixes an issue that arises where the count is always fetched when using get_post_counts() if the current post was never processed by the CLI command. 
